### PR TITLE
Autograder Update

### DIFF
--- a/Scripts/Assignment2Grading.ps1
+++ b/Scripts/Assignment2Grading.ps1
@@ -122,7 +122,7 @@ else {
     Write-Host "Failed to find key vault secrets access policy for grader identity"
 }
 
-$expectedValue = "@Microsoft.KeyVault(SecretUri=https://$KeyVault.vault.azure.net/secrets/$SecretName/)"
+$expectedValue = "@Microsoft.KeyVault(SecretUri=https://$KeyVault.vault.azure.net/secrets/$SecretName/*)"
 
 $appSettingValue = az webapp config appsettings list -n $WebAppName --resource-group $ResourceGroup | ConvertFrom-Json | Where-Object { $_.name -like $SecretName } | Select-Object -ExpandProperty value
 if ($appSettingValue -like $expectedValue ) {


### PR DESCRIPTION
This change allows for the secret version to be optionally included in the secret uri.

A secret's version number is included by default when copying a secret uri from the vault viewer. However, the autograder for assignment 2 assumes the version number of the secret uri should not be included in the uri, likely resulting in grading errors.